### PR TITLE
fix right border wrongly rendered

### DIFF
--- a/CustomDialogGui.asc
+++ b/CustomDialogGui.asc
@@ -1102,7 +1102,7 @@ function dialog_options_render(DialogOptionsRenderingInfo *info)
                             Game.SpriteHeight[CDG.borderDecoCornerUpright], 
                             CDG.borderDecoFrameRight, 0, 
                             Game.SpriteWidth[CDG.borderDecoFrameRight], 
-                            CDG.gui_height-Game.SpriteHeight[CDG.borderDecoCornerDownright]-Game.SpriteWidth[CDG.borderDecoFrameRight]);
+                            CDG.gui_height-Game.SpriteHeight[CDG.borderDecoCornerDownright]-Game.SpriteHeight[CDG.borderDecoCornerUpright]);
     
     // Corners
     info.Surface.DrawImage(0, 0, CDG.borderDecoCornerUpleft);


### PR DESCRIPTION
probable fix for bug reported by Dave here: 

https://www.adventuregamestudio.co.uk/forums/modules-plugins-tools/module-customdialoggui-1-9/msg636649979/#msg636649979

![image](https://user-images.githubusercontent.com/2244442/193421618-3b62eaac-1dd1-4fe0-9142-c32676b99978.png)


